### PR TITLE
Add GitHub syntax highlighting for .crb files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.crb linguist-language=Ruby


### PR DESCRIPTION
As per https://github.com/github/linguist/blob/master/docs/overrides.md